### PR TITLE
Declare end of support for standard version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 Quicktext is a Thunderbird extension, which has been created by Emil Hesslow. However, he was no longer able to update Quicktext or provide any kind of support. Thankfully he changed the license of Quicktext (and Quicktext Pro) to MPL 2.0 and shared its sources with the Thunderbird project, so others could update the extension to make it work with the most recent version of Thunderbird.
 
-Since Quicktext Pro is now released unter MPL 2.0 as well, the Thunderbird Council decided to base the [official version of Quicktext](https://addons.mozilla.org/de/thunderbird/addon/quicktext/) on the "pro" branch. However, the name of the extension remains just "Quicktext". The first official version including the pro features is 0.9.14. 
-
-The "standard" branch of Quicktext will not receive any further updates.
+**Note:** Since Quicktext Pro has been released under MPL 2.0 as well, the Thunderbird Council decided to base the [official version of Quicktext](https://addons.mozilla.org/de/thunderbird/addon/quicktext/) on the "Pro" version. However, the name of the extension remains just "Quicktext". The obsolete "Standard" branch of Quicktext will not receive any further updates.
 
 More information and usage descriptions can be found in the [wiki](https://github.com/thundernest/quicktext/wiki) of this repository.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Quicktext is a Thunderbird extension, which has been created by Emil Hesslow. However, he was no longer able to update Quicktext or provide any kind of support. Thankfully he changed the license of Quicktext (and Quicktext Pro) to MPL 2.0 and shared its sources with the Thunderbird project, so others could update the extension to make it work with the most recent version of Thunderbird.
 
-Volunteers will try to keep Quicktext going, but support will be limited. You may use the [issue section](https://github.com/thundernest/quicktext/issues) of this repository to report bugs, but do not expect fast responses. You may also discuss Quicktext related issues with other users at https://discourse.mozilla.org/c/thunderbird.
+Since Quicktext Pro is now released unter MPL 2.0 as well, the Thunderbird Council decided to base the [official version of Quicktext](https://addons.mozilla.org/de/thunderbird/addon/quicktext/) on the "pro" branch. However, the name of the extension remains just "Quicktext". The first official version including the pro features is 0.9.14. 
+
+The "standard" branch of Quicktext will not receive any further updates.
 
 More information and usage descriptions can be found in the [wiki](https://github.com/thundernest/quicktext/wiki) of this repository.


### PR DESCRIPTION
The "Standard" branch is now obsolete. Declare end of support for standard version.

I would still keep this branch, but not as default. The "Pro" branch is fixed and should be set as default.