### PR TITLE
Pro

### DIFF
--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -193,6 +193,7 @@ var quicktext = {
               menupopup.appendChild(toolbarbutton);
             }
           }
+          toolbarbuttonGroup = null;
 
           // Update the keyshortcuts
           for (var j = 0; j < textLength; j++)
@@ -231,12 +232,12 @@ var quicktext = {
           //rebuild via copy from the quicktext toolbar - loop over toolbarbuttons inside toolbar
           for (let i = 0; i < toolbar.childNodes.length; i++)
           {
+            let menu;
             let node = toolbar.childNodes[i];
             switch (node.nodeName)
             {
               case "toolbarbutton":
                 // Check if the group is collapse or not
-                var menu;
                 if (node.getAttribute("type") == "menu")
                 {
                   menu = document.createElement("menu");
@@ -260,6 +261,7 @@ var quicktext = {
                 rootElement.appendChild(document.createElement("menuseparator"));
                 break;
             }
+            menu = null;
           }
           
         }

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -66,9 +66,9 @@ var quicktext = {
     // Remove the observer
     gQuicktext.removeObserver(this);
 
-    window.removeEventListener("keypress", function(e) { quicktext.windowKeyPress(e); }, false);
-    window.removeEventListener("keydown", function(e) { quicktext.windowKeyDown(e); }, false);
-    window.removeEventListener("keyup", function(e) { quicktext.windowKeyUp(e); }, false);
+    window.removeEventListener("keypress", function(e) { quicktext.windowKeyPress(e); }, true);
+    window.removeEventListener("keydown", function(e) { quicktext.windowKeyDown(e); }, true);
+    window.removeEventListener("keyup", function(e) { quicktext.windowKeyUp(e); }, true);
 
     // Remove the eventlistener from the editor
     var contentFrame = GetCurrentEditorElement();
@@ -77,6 +77,8 @@ var quicktext = {
     // Remove the eventlistener for the popup-menu.
     var menu = document.getElementById("msgComposeContext");
     menu.removeEventListener("popupshowing", function(e) { quicktext.popupshowing(e); }, false);
+
+    window.removeEventListener("aftercustomization", function() { quicktext.updateGUI(); } , false);
   }
 ,
 

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -816,15 +816,3 @@ var quicktext = {
     Components.interfaces.nsIFactory,
     ])
 }
-
-// Make Array.indexOf work in Firefox versions older than 1.1
-if  (!Array.prototype.indexOf)
-{
-  Array.prototype.indexOf = function(item)
-  {
-    for (var i = 0; i < this.length; i++)
-        if (this[i] == item)
-            return i;
-    return -1;
-  };
-}

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -271,8 +271,6 @@ var quicktext = {
       
     }
 
-      // This is for personalscripts  
-      // this.updateOwnVariables("quicktext.insertVariable");
     //add event listeners
     let items = document.getElementsByClassName("customEventListenerForDynamicMenu");
     for (let i=0; i < items.length; i++)

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -359,7 +359,7 @@ var quicktext = {
       this.insertBody(text.text, text.type, aHandleTransaction);
 
       // If we insert any headers we maybe needs to return the placement of the focus
-      setTimeout("quicktext.moveFocus();", 1);
+      setTimeout(function () {quicktext.moveFocus();}, 1);
     }
   }
 ,

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -46,14 +46,13 @@ var quicktext = {
       var contentFrame = GetCurrentEditorElement();
       contentFrame.addEventListener("keypress", function(e) { quicktext.editorKeyPress(e); }, false);
 
-    	// Add an eventlistener for the popup-menu.
-    	var menu = document.getElementById("msgComposeContext");
-	    menu.addEventListener("popupshowing", function(e) { quicktext.popupshowing(e); }, false);
+      // Add an eventlistener for the popup-menu.
+      var menu = document.getElementById("msgComposeContext");
+      menu.addEventListener("popupshowing", function(e) { quicktext.popupshowing(e); }, false);
 
-      // Need to update GUI when the Quicktext-button is added to the toolbar.
-      var composeToolbar = (document.getElementById("composeToolbar")) ? document.getElementById("composeToolbar") : document.getElementById("composeToolbar2");
-      if (composeToolbar)
-        composeToolbar.addEventListener("DOMNodeInserted", function(e) { quicktext.toolbarButtonAdded(e); }, false);
+      // Need to update GUI when the Quicktext-button is added to the toolbar (updating on ANY change to the toolbar is much more simple, and it does not hurt) 
+      window.addEventListener("aftercustomization", function() { quicktext.updateGUI(); } , false);
+
     }
   }
 ,
@@ -78,11 +77,6 @@ var quicktext = {
     // Remove the eventlistener for the popup-menu.
     var menu = document.getElementById("msgComposeContext");
     menu.removeEventListener("popupshowing", function(e) { quicktext.popupshowing(e); }, false);
-
-    // Need to update GUI when the Quicktext-button is added to the toolbar.
-    var composeToolbar = (document.getElementById("composeToolbar")) ? document.getElementById("composeToolbar") : document.getElementById("composeToolbar2");
-    if (composeToolbar)
-      composeToolbar.removeEventListener("DOMNodeInserted", function(e) { quicktext.toolbarButtonAdded(e); }, false);
   }
 ,
 
@@ -287,12 +281,6 @@ var quicktext = {
     var hidden = !gQuicktext.viewPopup;
     document.getElementById("quicktext-popup").hidden = hidden;
     document.getElementById("quicktext-popupsep").hidden = hidden;
-  }
-,
-  toolbarButtonAdded: function(aEvent)
-  {
-    if (aEvent.originalTarget && aEvent.originalTarget.getAttribute("id") == "button-quicktext")
-      this.updateGUI();
   }
 ,
   openSettings: function()

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -75,8 +75,8 @@ var quicktext = {
     var contentFrame = GetCurrentEditorElement();
     contentFrame.removeEventListener("keypress", function(e) { quicktext.editorKeyPress(e); }, false);
 
-  	// Remove the eventlistener for the popup-menu.
-  	var menu = document.getElementById("msgComposeContext");
+    // Remove the eventlistener for the popup-menu.
+    var menu = document.getElementById("msgComposeContext");
     menu.removeEventListener("popupshowing", function(e) { quicktext.popupshowing(e); }, false);
 
     // Need to update GUI when the Quicktext-button is added to the toolbar.
@@ -86,11 +86,11 @@ var quicktext = {
   }
 ,
 
-	/**
-	 * This is called when the var gMsgCompose is init. We now take
-	 * the extraArguments value and listen for state changes so
-	 * we know when the editor is finished.
-	 */
+  /**
+   * This is called when the var gMsgCompose is init. We now take
+   * the extraArguments value and listen for state changes so
+   * we know when the editor is finished.
+   */
   windowInit: function()
   {
   	gMsgCompose.RegisterStateListener(quicktextStateListener);

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -275,9 +275,6 @@ var quicktext = {
     {
       items[i].addEventListener("command", function() { quicktext.insertTemplate(this.getAttribute("i"), this.getAttribute("j")); }, true);
     }
-
-    
-    this.visibleToolbar();
   }
 ,
   popupshowing: function(aEvent)
@@ -293,25 +290,11 @@ var quicktext = {
     settingsHandle.focus();
   }
 ,
-  toogleToolbar: function()
-  {
-    gQuicktext.viewToolbar = !gQuicktext.viewToolbar;
-  }
+  //unused
+  toogleToolbar: function() {}
 ,
-  visibleToolbar: function()
-  {
-    // Set the view of the toolbar to what it should be
-    if (gQuicktext.viewToolbar)
-    {
-      document.getElementById("quicktext-view").setAttribute("checked", true);
-      document.getElementById("quicktext-toolbar").removeAttribute("collapsed");
-    }
-    else
-    {
-      document.getElementById("quicktext-view").removeAttribute("checked");
-      document.getElementById("quicktext-toolbar").setAttribute("collapsed", true);
-    }    
-  }
+  //unused
+  visibleToolbar: function() {}
 ,
 
   /*
@@ -779,9 +762,6 @@ var quicktext = {
     {
       case "updatesettings":
         this.updateGUI();
-        break;
-      case "updatetoolbar":
-        this.visibleToolbar();
         break;
     }
   }

--- a/chrome/content/quicktext.xul
+++ b/chrome/content/quicktext.xul
@@ -122,10 +122,6 @@
               <menuitem label="&quicktext.version.label;" oncommand="quicktext.insertVariable('VERSION');" />
             </menupopup>
           </menu>
-          <menu label="&quicktext.ownVariables.label;" id="quicktext-own-vars" hidden="true">
-            <menupopup>
-            </menupopup>
-          </menu>
         </menupopup>
       </toolbarbutton>
       <toolbarbutton type="menu" id="quicktext-other" label="&quicktext.other.label;">

--- a/chrome/content/quicktext.xul
+++ b/chrome/content/quicktext.xul
@@ -40,7 +40,7 @@
   <toolbarpalette id="MsgComposeToolbarPalette">
     <toolbarbutton class="toolbarbutton-1" type="menu"
                    id="button-quicktext" label="&quicktext.shortname.label;"
-                   orient="vertical">
+                   orient="horizontal">
       <menupopup />
     </toolbarbutton>
   </toolbarpalette>

--- a/chrome/content/quicktext.xul
+++ b/chrome/content/quicktext.xul
@@ -52,10 +52,6 @@
 		</menu>
 	</popup>
 
-  <menupopup id="menu_View_Popup">
-    <menuitem id="quicktext-view" type="checkbox" label="&quicktext.label;" oncommand="quicktext.toogleToolbar();"/>
-  </menupopup>
-
   <menupopup id="taskPopup">
     <menuitem id="quicktext-settings" label="&quicktext.label;" oncommand="quicktext.openSettings();" insertafter="tasksMenuAddressBook" class="menu-iconic quicktext-icon menuitem-iconic" />
     <menuseparator insertafter="tasksMenuAddressBook" />

--- a/chrome/content/settings.js
+++ b/chrome/content/settings.js
@@ -547,7 +547,8 @@ var quicktext =
             var textElem = document.createElement("menuitem");
             var text = gQuicktext.getText(i, j, true);
             textElem.setAttribute('label', text.name);
-            textElem.setAttribute('oncommand', "quicktext.insertVariable('TEXT="+ group.name +"|"+ text.name +"');");
+            textElem.setAttribute('group', group.name);
+            textElem.addEventListener("command", function() { quicktext.insertVariable("TEXT="+ this.getAttribute("group") +"|"+ this.getAttribute("label")); });
             textElem = groupParent.appendChild(textElem);
           }
         }
@@ -572,7 +573,7 @@ var quicktext =
         var script = gQuicktext.getScript(i, true);
         var textElem = document.createElement("menuitem");
         textElem.setAttribute('label', script.name);
-        textElem.setAttribute('oncommand', "quicktext.insertVariable('SCRIPT="+ script.name +"');");
+        textElem.addEventListener("command", function() { quicktext.insertVariable("SCRIPT="+ this.getAttribute("label")); });
         textElem = parent.appendChild(textElem);
       }
     }

--- a/chrome/content/settings.xul
+++ b/chrome/content/settings.xul
@@ -236,10 +236,6 @@
                               </menu>
                               <menu label="&quicktext.templates.label;" id="quicktext-other-texts" />
                               <menu label="&quicktext.scripts.label;" id="variables-scripts" />
-                              <menu label="&quicktext.ownVariables.label;" id="quicktext-own-vars" hidden="true">
-                                <menupopup>
-                                </menupopup>
-                              </menu>
                             </menupopup>
                           </menu>
                         </vbox>

--- a/chrome/locale/de/quicktext.dtd
+++ b/chrome/locale/de/quicktext.dtd
@@ -85,7 +85,5 @@
 <!ENTITY quicktext.keyword.label "Schlüsselwort">
 <!ENTITY quicktext.browse.label "Suchen">
 
-<!ENTITY quicktext.ownVariables.label "Ihre eigenen Variablen">
-
 <!ENTITY quicktext.insertTextFromFileAsHTML.label "Datei als HTML einfügen">
 <!ENTITY quicktext.insertTextFromFileAsText.label "Datei als Text einfügen">

--- a/chrome/locale/en-US/quicktext.dtd
+++ b/chrome/locale/en-US/quicktext.dtd
@@ -85,7 +85,5 @@
 <!ENTITY quicktext.keyword.label "Keyword">
 <!ENTITY quicktext.browse.label "Browse">
 
-<!ENTITY quicktext.ownVariables.label "Your own variables">
-
 <!ENTITY quicktext.insertTextFromFileAsHTML.label "Insert file as HTML">
 <!ENTITY quicktext.insertTextFromFileAsText.label "Insert file as text">

--- a/chrome/locale/fr/quicktext.dtd
+++ b/chrome/locale/fr/quicktext.dtd
@@ -85,7 +85,5 @@
 <!ENTITY quicktext.keyword.label "Mot-clé">
 <!ENTITY quicktext.browse.label "Parcourir">
 
-<!ENTITY quicktext.ownVariables.label "Vos propres variables">
-
 <!ENTITY quicktext.insertTextFromFileAsHTML.label "Insérer un fichier en HTML">
 <!ENTITY quicktext.insertTextFromFileAsText.label "Insérer un fichier en texte">

--- a/chrome/locale/ja/quicktext.dtd
+++ b/chrome/locale/ja/quicktext.dtd
@@ -85,7 +85,5 @@
 <!ENTITY quicktext.keyword.label "キーワード">
 <!ENTITY quicktext.browse.label "参照">
 
-<!ENTITY quicktext.ownVariables.label "あなたのタグ">
-
 <!ENTITY quicktext.insertTextFromFileAsHTML.label "ファイルを HTML として挿入">
 <!ENTITY quicktext.insertTextFromFileAsText.label "ファイルをテキストとして挿入">

--- a/chrome/locale/sv-SE/quicktext.dtd
+++ b/chrome/locale/sv-SE/quicktext.dtd
@@ -85,7 +85,5 @@
 <!ENTITY quicktext.keyword.label "Nyckelord">
 <!ENTITY quicktext.browse.label "Bläddra">
 
-<!ENTITY quicktext.ownVariables.label "Dina egna variabler">
-
 <!ENTITY quicktext.insertTextFromFileAsHTML.label "Infoga fil som HTML">
 <!ENTITY quicktext.insertTextFromFileAsText.label "Infoga fil som text">

--- a/components/wzQuicktext.js
+++ b/components/wzQuicktext.js
@@ -170,8 +170,16 @@ wzQuicktext.prototype = {
     if (this.mPrefBranch.getPrefType("menuCollapse") == this.mPrefBranch.PREF_BOOL)
       this.mCollapseGroup = this.mPrefBranch.getBoolPref("menuCollapse");
 
-    if (this.mPrefBranch.getPrefType("keywordKey") == this.mPrefBranch.PREF_INT)
+    if (this.mPrefBranch.getPrefType("keywordKey") == this.mPrefBranch.PREF_INT) {
       this.mKeywordKey = this.mPrefBranch.getIntPref("keywordKey");
+      
+      //migrate old keywordKey if differs from default(9)
+      if (this.mPrefBranchOld.prefHasUserValue("keywordKey") && this.mPrefBranchOld.getPrefType("keywordKey") == this.mPrefBranchOld.PREF_INT && this.mPrefBranchOld.getIntPref("keywordKey") != 9) {
+        this.mKeywordKey = this.mPrefBranchOld.getIntPref("keywordKey");
+        this.mPrefBranchOld.setIntPref("keywordKey", 9);
+        this.mPrefBranch.setIntPref("keywordKey", this.mKeywordKey);
+      }
+    }
 
     if (this.mPrefBranch.getPrefType("shortcutTypeAdv") == this.mPrefBranch.PREF_BOOL)
       this.mShortcutTypeAdv = this.mPrefBranch.getBoolPref("shortcutTypeAdv");
@@ -187,7 +195,7 @@ wzQuicktext.prototype = {
       this.mDefaultImport = this.mPrefBranch.getCharPref("defaultImport");
       
       //migrate: Use (and clear) old data if present
-      if (this.mPrefBranchOld.prefHasUserValue("defaultImport") && this.mPrefBranchOld.getCharPref("defaultImport") != "") {
+      if (this.mPrefBranchOld.prefHasUserValue("defaultImport") && this.mPrefBranchOld.getPrefType("defaultImport") == this.mPrefBranchOld.PREF_STRING && this.mPrefBranchOld.getCharPref("defaultImport") != "") {
         this.mDefaultImport = this.mPrefBranchOld.getCharPref("defaultImport");
         this.mPrefBranchOld.setCharPref("defaultImport", "");
         this.mPrefBranch.setCharPref("defaultImport", this.mDefaultImport);

--- a/components/wzQuicktext.js
+++ b/components/wzQuicktext.js
@@ -57,7 +57,7 @@ wzQuicktext.prototype = {
   set defaultImport(aDefaultImport)
   {
     this.mDefaultImport = aDefaultImport;
-    this.setUnicharPref("defaultImport", aDefaultImport);
+    this.mPrefBranch.setCharPref("defaultImport", aDefaultImport);
 
     return this.mDefaultImport;
   }
@@ -184,7 +184,15 @@ wzQuicktext.prototype = {
     
     if (this.mPrefBranch.getPrefType("defaultImport") == this.mPrefBranch.PREF_STRING)
     {
-      this.mDefaultImport = this.getLocalizedUnicharPref("defaultImport");
+      this.mDefaultImport = this.mPrefBranch.getCharPref("defaultImport");
+      
+      //migrate: Use (and clear) old data if present
+      if (this.mPrefBranchOld.prefHasUserValue("defaultImport") && this.mPrefBranchOld.getCharPref("defaultImport") != "") {
+        this.mDefaultImport = this.mPrefBranchOld.getCharPref("defaultImport");
+        this.mPrefBranchOld.setCharPref("defaultImport", "");
+        this.mPrefBranch.setCharPref("defaultImport", this.mDefaultImport);
+      }
+      
       if (this.mDefaultImport != null)
       {
         var defaultImport = this.mDefaultImport.split(";");
@@ -917,6 +925,7 @@ wzQuicktext.prototype = {
   /*
    * PREF FUNCTIONS
    */
+  //unused, only used to store filenames/webaddr, no need for fancy stuff - use getCharPref now
   getLocalizedUnicharPref: function (aPrefName)
   {
     try {
@@ -926,6 +935,7 @@ wzQuicktext.prototype = {
     return null;        // quiet warnings
   }
 ,
+  //unused, only used to store filenames/webaddr, no need for fancy stuff - use setCharPref now
   setUnicharPref: function (aPrefName, aPrefValue)
   {
     try {

--- a/components/wzQuicktext.js
+++ b/components/wzQuicktext.js
@@ -24,7 +24,6 @@ wzQuicktext.prototype = {
   mEditingScripts:      [],
   mPrefService:         null,
   mPrefBranch:          null,
-  mViewToolbar:         true,
   mCollapseGroup:       true,
   mDefaultImport:       "",
   mKeywordKey:          9,
@@ -35,16 +34,9 @@ wzQuicktext.prototype = {
   mOS:                  "WINNT",
   mCollapseState:       ""
 ,
-  get viewToolbar() { return this.mViewToolbar; },
-  set viewToolbar(aViewToolbar)
-  {
-    this.mViewToolbar = aViewToolbar;
-    this.mPrefBranch.setBoolPref("toolbar", aViewToolbar);
-
-    this.notifyObservers("updatetoolbar", "");
-
-    return this.mViewToolbar;
-  }
+  //obsolete but cannot remove due to IDL
+  get viewToolbar() { return true; },
+  set viewToolbar(aViewToolbar) {}
 ,
   //obsolete but cannot remove due to IDL
   get viewPopup() { return false; },
@@ -175,9 +167,6 @@ wzQuicktext.prototype = {
     }
 
     // Get prefs
-    if (this.mPrefBranch.getPrefType("toolbar") == this.mPrefBranch.PREF_BOOL)
-      this.mViewToolbar = this.mPrefBranch.getBoolPref("toolbar");
-
     if (this.mPrefBranch.getPrefType("menuCollapse") == this.mPrefBranch.PREF_BOOL)
       this.mCollapseGroup = this.mPrefBranch.getBoolPref("menuCollapse");
 

--- a/components/wzQuicktext.js
+++ b/components/wzQuicktext.js
@@ -149,7 +149,7 @@ wzQuicktext.prototype = {
     this.mOS = appInfo.OS;
 
     this.mPrefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-    this.mPrefBranch = this.mPrefService.getBranch("quicktext.");
+    this.mPrefBranch = this.mPrefService.getBranch("extensions.quicktext.");
 
     this.mGroup = [];
     this.mTexts = [];

--- a/components/wzQuicktext.js
+++ b/components/wzQuicktext.js
@@ -172,8 +172,7 @@ wzQuicktext.prototype = {
 
     if (this.mPrefBranch.getPrefType("keywordKey") == this.mPrefBranch.PREF_INT) {
       this.mKeywordKey = this.mPrefBranch.getIntPref("keywordKey");
-      
-      //migrate old keywordKey if differs from default(9)
+      //migrate old keywordKey (and reset to default), if differs from default(9)
       if (this.mPrefBranchOld.prefHasUserValue("keywordKey") && this.mPrefBranchOld.getPrefType("keywordKey") == this.mPrefBranchOld.PREF_INT && this.mPrefBranchOld.getIntPref("keywordKey") != 9) {
         this.mKeywordKey = this.mPrefBranchOld.getIntPref("keywordKey");
         this.mPrefBranchOld.setIntPref("keywordKey", 9);
@@ -181,19 +180,32 @@ wzQuicktext.prototype = {
       }
     }
 
-    if (this.mPrefBranch.getPrefType("shortcutTypeAdv") == this.mPrefBranch.PREF_BOOL)
+    if (this.mPrefBranch.getPrefType("shortcutTypeAdv") == this.mPrefBranch.PREF_BOOL) {
       this.mShortcutTypeAdv = this.mPrefBranch.getBoolPref("shortcutTypeAdv");
+      //migrate old shortcutTypeAdv (and reset to default), if differs from default(false)
+      if (this.mPrefBranchOld.prefHasUserValue("shortcutTypeAdv") && this.mPrefBranchOld.getPrefType("shortcutTypeAdv") == this.mPrefBranchOld.PREF_BOOL && this.mPrefBranchOld.getBoolPref("shortcutTypeAdv") != false) {
+        this.mShortcutTypeAdv = this.mPrefBranchOld.getBoolPref("shortcutTypeAdv");
+        this.mPrefBranchOld.setBoolPref("shortcutTypeAdv", false);
+        this.mPrefBranch.setBoolPref("shortcutTypeAdv", this.mShortcutTypeAdv);
+      }
+    }
 
-    if (this.mPrefBranch.getPrefType("shortcutModifier") == this.mPrefBranch.PREF_STRING)
+    if (this.mPrefBranch.getPrefType("shortcutModifier") == this.mPrefBranch.PREF_STRING) {
       this.mShortcutModifier = this.mPrefBranch.getCharPref("shortcutModifier");
+      //migrate: Use (and clear) old data if present
+      if (this.mPrefBranchOld.prefHasUserValue("shortcutModifier") && this.mPrefBranchOld.getPrefType("shortcutModifier") == this.mPrefBranchOld.PREF_STRING && this.mPrefBranchOld.getCharPref("shortcutModifier") != "") {
+        this.mShortcutModifier = this.mPrefBranchOld.getCharPref("shortcutModifier");
+        this.mPrefBranchOld.setCharPref("shortcutModifier", "");
+        this.mPrefBranch.setCharPref("shortcutModifier", this.mShortcutModifier);
+      }
+    }
 
     if (this.mPrefBranch.getPrefType("collapseState") == this.mPrefBranch.PREF_STRING)
       this.mCollapseState = this.mPrefBranch.getCharPref("collapseState");
     
     if (this.mPrefBranch.getPrefType("defaultImport") == this.mPrefBranch.PREF_STRING)
     {
-      this.mDefaultImport = this.mPrefBranch.getCharPref("defaultImport");
-      
+      this.mDefaultImport = this.mPrefBranch.getCharPref("defaultImport");      
       //migrate: Use (and clear) old data if present
       if (this.mPrefBranchOld.prefHasUserValue("defaultImport") && this.mPrefBranchOld.getPrefType("defaultImport") == this.mPrefBranchOld.PREF_STRING && this.mPrefBranchOld.getCharPref("defaultImport") != "") {
         this.mDefaultImport = this.mPrefBranchOld.getCharPref("defaultImport");

--- a/components/wzQuicktextVar.js
+++ b/components/wzQuicktextVar.js
@@ -1123,16 +1123,6 @@ wzQuicktextVar.prototype = {
 
     return aStr;
   }
-,
-  QueryInterface: function(aIID)
-  {
-    if (aIID.equals(Components.interfaces.wzIQuicktextVar) ||
-        aIID.equals(Components.interfaces.nsISupports))
-      return this;
-
-    Components.returnCode = Components.results.NS_ERROR_NO_INTERFACE;
-    return null;
-  }
 }
 
 /**

--- a/components/wzQuicktextVar.js
+++ b/components/wzQuicktextVar.js
@@ -73,7 +73,8 @@ function wzQuicktextVar()
 
   // Add prefs for preferences
   this.mPrefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-  this.mPrefBranch = this.mPrefService.getBranch("quicktext.");
+  this.mPrefBranch = this.mPrefService.getBranch("extensions.quicktext.");
+  this.mPrefBranchOld = this.mPrefService.getBranch("quicktext.");
 }
 
 wzQuicktextVar.prototype = {
@@ -879,8 +880,9 @@ wzQuicktextVar.prototype = {
     this.mData['COUNTER'].checked = true;
     this.mData['COUNTER'].data = 0;
 
-    if (this.mPrefBranch.prefHasUserValue("counter"))
-      this.mData['COUNTER'].data = this.mPrefBranch.getIntPref("counter");
+    let oldPrefValue = this.mPrefBranchOld.prefHasUserValue("counter") ? this.mPrefBranchOld.getIntPref("counter") : 0;
+    let newPrefValue = this.mPrefBranch.prefHasUserValue("counter") ? this.mPrefBranch.getIntPref("counter") : 0;
+    this.mData['COUNTER'].data = Math.max(oldPrefValue, newPrefValue);
 
     this.mData['COUNTER'].data++;
     this.mPrefBranch.setIntPref("counter", this.mData['COUNTER'].data);

--- a/components/wzQuicktextVar.js
+++ b/components/wzQuicktextVar.js
@@ -1152,15 +1152,3 @@ function TrimString(aStr)
   if (!aStr) return "";
   return aStr.replace(/(^\s+)|(\s+$)/g, '')
 }
-
-// Make Array.indexOf work in Firefox versions older than 1.1
-if  (!Array.prototype.indexOf)
-{
-  Array.prototype.indexOf = function(item)
-  {
-    for (var i = 0; i < this.length; i++)
-        if (this[i] == item)
-            return i;
-    return -1;
-  };
-}

--- a/defaults/preferences/quicktext.js
+++ b/defaults/preferences/quicktext.js
@@ -1,8 +1,7 @@
-pref("quicktext.defaultImport", "");
-pref("quicktext.menuCollapse", true);
-pref("quicktext.toolbar", true);
-pref("quicktext.popup", false);
-pref("quicktext.keywordKey", 9);
-pref("quicktext.shortcutModifier", "alt");
-pref("quicktext.shortcutTypeAdv", false);
-pref("quicktext.firstTime", true);
+pref("extensions.quicktext.defaultImport", "");
+pref("extensions.quicktext.menuCollapse", true);
+pref("extensions.quicktext.toolbar", true);
+pref("extensions.quicktext.popup", false);
+pref("extensions.quicktext.keywordKey", 9);
+pref("extensions.quicktext.shortcutModifier", "alt");
+pref("extensions.quicktext.shortcutTypeAdv", false);

--- a/defaults/preferences/quicktext.js
+++ b/defaults/preferences/quicktext.js
@@ -1,6 +1,5 @@
 pref("extensions.quicktext.defaultImport", "");
 pref("extensions.quicktext.menuCollapse", true);
-pref("extensions.quicktext.popup", false);
 pref("extensions.quicktext.keywordKey", 9);
 pref("extensions.quicktext.shortcutModifier", "alt");
 pref("extensions.quicktext.shortcutTypeAdv", false);

--- a/defaults/preferences/quicktext.js
+++ b/defaults/preferences/quicktext.js
@@ -1,6 +1,5 @@
 pref("extensions.quicktext.defaultImport", "");
 pref("extensions.quicktext.menuCollapse", true);
-pref("extensions.quicktext.toolbar", true);
 pref("extensions.quicktext.popup", false);
 pref("extensions.quicktext.keywordKey", 9);
 pref("extensions.quicktext.shortcutModifier", "alt");

--- a/install.rdf
+++ b/install.rdf
@@ -4,8 +4,10 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>{8845E3B3-E8FB-40E2-95E9-EC40294818C4}</em:id>
+    <em:type>2</em:type> <!-- type=extension --> 
     <em:name>Quicktext</em:name>
     <em:version>0.9.14</em:version>
+    <em:unpack>true</em:unpack>
     <em:description>Adds a toolbar with unlimited number of text to quickly insert. It's also possible to use variables like [[TO=firstname]]. With settings for everything.</em:description>
     <em:creator>Emil Hesslow</em:creator>
     <em:contributor>R Kent James</em:contributor>


### PR DESCRIPTION
This PR fixes 23 of 27 AMO warnings.

The remaining 4 warnings are:
- Banned or deprecated JavaScript Identifier (3x) 
- Access to the `evalInSandbox` global (1x)

The 3 "banned" warnings are due to the lazy async-to-sync code suggested in the [Add-ons_Guide_57](https://wiki.mozilla.org/Thunderbird/Add-ons_Guide_57) :
```
filePicker.open(result => {
      rv = result;
      done = true;
    });
 
    let thread = Components.classes["@mozilla.org/thread-manager;1"].getService().currentThread;
    while (!done) {
      thread.processNextEvent(true);
    }
```

I used this trick with two other callbacks. I do not see how to get this to true async without heavy rewrite. I could limit the while loop to a max of 5 sec, to prevent deadlocks?


**The other warning is more severe I think.** evalInSandbox has been deprecated but I could not find a replacement. Any suggestions? It is used for the SCRIPT tag, which is the main feature of the PRO version...