### PR TITLE
Issue27 focus switching

### DIFF
--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -555,22 +555,24 @@ var quicktext = {
     finder.caseSensitive = true;
     finder.findBackwards = false;
 
-    var found = false;
-    while ((foundRange = finder.Find("[[CURSOR]]", aSearchRange, startRange, endRange)) != null)
-    {
-      found = true;
-      aEditor.selection.removeAllRanges();
-      aEditor.selection.addRange(foundRange);
-      aEditor.selection.deleteFromDocument();
-      startRange.setEnd(foundRange.endContainer, foundRange.endOffset);
-      startRange.setStart(foundRange.endContainer, foundRange.endOffset);
-    }
+    setTimeout(function() {
+      var found = false;
+      while ((foundRange = finder.Find("[[CURSOR]]", aSearchRange, startRange, endRange)) != null)
+      {
+        found = true;
+        aEditor.selection.removeAllRanges();
+        aEditor.selection.addRange(foundRange);
+        aEditor.selection.deleteFromDocument();
+        startRange.setEnd(foundRange.endContainer, foundRange.endOffset);
+        startRange.setStart(foundRange.endContainer, foundRange.endOffset);
+      }
 
-    if (!found)
-    {
-      aEditor.selection.removeAllRanges();
-      aEditor.selection.addRange(endRange);
-    }
+      if (!found)
+      {
+        aEditor.selection.removeAllRanges();
+        aEditor.selection.addRange(endRange);
+      }
+    });
   }
 ,
   dumpTree: function(aNode, aLevel)

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -333,6 +333,14 @@ var quicktext = {
       this.insertHeaders(text);
       this.insertSubject(text.subject);
       this.insertAttachments(text.attachments);
+
+      if (text.text != "" && text.text.indexOf('[[CURSOR]]') > -1)
+      {
+        // only if we really have text to insert with a [[CURSOR]] tag,
+        // focus the message body first
+        this.focusMessageBody();
+      }
+
       this.insertBody(text.text, text.type, aHandleTransaction);
 
       // If we insert any headers we maybe needs to return the placement of the focus
@@ -469,6 +477,17 @@ var quicktext = {
     {
       this.mLastFocusedElement.focus();
       this.mLastFocusedElement = null;
+    }
+  }
+,
+  focusMessageBody: function()
+  {
+    // advance focus until we are at the message body
+    var maxsteps = 50;
+    for (var i = 0; this.mLastFocusedElement.name != "browser.message.body" && i < maxsteps; i++)
+    {
+      document.commandDispatcher.advanceFocus();
+      this.mLastFocusedElement = (document.commandDispatcher.focusedWindow != window) ? document.commandDispatcher.focusedWindow : document.commandDispatcher.focusedElement;
     }
   }
 ,


### PR DESCRIPTION
This patch moves the focus to the message body if  `[[CURSOR]]` is present in
the template text.

It skips the focus switch if only headers or subject are modified or if the template text
has no `[[CURSOR]]` marker.

`focusMessageBody` could be improved to focus the window directly. 
I could only achieve that by stepping through via `document.commandDispatcher.advanceFocus();`
until the right element has the focus. (That's the same as pressing TAB multiple times in the header/subject area)