### PR TITLE
feat(tag): add monthname tag

### DIFF
--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -107,7 +107,7 @@ var quicktext = {
   {
     // Set the date/time in the variablemenu
     var timeStamp = new Date();
-    let fields = ["date-short", "date-long", "time-noseconds", "time-seconds"];
+    let fields = ["date-short", "date-long", "date-monthname", "time-noseconds", "time-seconds"];
     for (let i=0; i < fields.length; i++) {
         let field = fields[i];
         let fieldtype = field.split("-")[0];

--- a/chrome/content/quicktext.xul
+++ b/chrome/content/quicktext.xul
@@ -111,6 +111,7 @@
             <menupopup>
               <menuitem id="date-short" oncommand="quicktext.insertVariable('DATE');" />
               <menuitem id="date-long" oncommand="quicktext.insertVariable('DATE=long');" />
+              <menuitem id="date-monthname" oncommand="quicktext.insertVariable('DATE=monthname');" />
               <menuitem id="time-noseconds" oncommand="quicktext.insertVariable('TIME');" />
               <menuitem id="time-seconds" oncommand="quicktext.insertVariable('TIME=seconds');" />
             </menupopup>

--- a/chrome/content/settings.js
+++ b/chrome/content/settings.js
@@ -470,7 +470,7 @@ var quicktext =
 
     // Set the date/time in the variablemenu
     var timeStamp = new Date();
-    let fields = ["date-short", "date-long", "time-noseconds", "time-seconds"];
+    let fields = ["date-short", "date-long", "date-monthname", "time-noseconds", "time-seconds"];
     for (let i=0; i < fields.length; i++) {
         let field = fields[i];
         let fieldtype = field.split("-")[0];

--- a/chrome/content/settings.xul
+++ b/chrome/content/settings.xul
@@ -221,6 +221,7 @@
                                 <menupopup>
                                   <menuitem id="date-short" oncommand="quicktext.insertVariable('DATE');" />
                                   <menuitem id="date-long" oncommand="quicktext.insertVariable('DATE=long');" />
+                                  <menuitem id="date-monthname" oncommand="quicktext.insertVariable('DATE=monthname');" />
                                   <menuitem id="time-noseconds" oncommand="quicktext.insertVariable('TIME');" />
                                   <menuitem id="time-seconds" oncommand="quicktext.insertVariable('TIME=seconds');" />
                                 </menupopup>

--- a/chrome/content/utils.js
+++ b/chrome/content/utils.js
@@ -14,6 +14,7 @@ var quicktextUtils = {
         let options = {};
         options["date-short"] = { dateStyle: "short" }; 
         options["date-long"] = { dateStyle: "long" }; 
+        options["date-monthname"] = { month: "long" }; 
         options["time-noseconds"] = { timeStyle: "short" }; 
         options["time-seconds"] = { timeStyle: "long" }; 
         return new Services.intl.DateTimeFormat(undefined, options[format.toLowerCase()]).format(timeStamp)
@@ -23,6 +24,7 @@ var quicktextUtils = {
         let options = {};
         options["date-short"] = { year: "numeric", month: "2-digit", day: "2-digit" }; 
         options["date-long"] = { weekday: "long", year: "numeric", month: "long", day: "2-digit" };
+        options["date-monthname"] = { month: "long" };
         options["time-noseconds"] = { hour: "2-digit", minute: "2-digit" }; 
         options["time-seconds"] = { hour: "2-digit", minute: "2-digit", second: "2-digit" };
         return new Intl.DateTimeFormat(undefined, options[format.toLowerCase()]).format(timeStamp);
@@ -39,6 +41,9 @@ var quicktextUtils = {
             return dateTimeService.FormatTime("", dateTimeService.timeFormatNoSeconds, timeStamp.getHours(), timeStamp.getMinutes(), timeStamp.getSeconds())
           case "time-seconds":
             return dateTimeService.FormatTime("", dateTimeService.timeFormatSeconds, timeStamp.getHours(), timeStamp.getMinutes(), timeStamp.getSeconds())
+          case "date-monthname":
+            return dateTimeService.FormatDate("", dateTimeService.dateFormatLong, timeStamp.getMonth()+1);
+          
         }
       }
     }

--- a/components/wzQuicktextVar.js
+++ b/components/wzQuicktextVar.js
@@ -949,7 +949,7 @@ wzQuicktextVar.prototype = {
     this.mData['TIME'].data = {};
 
     var timeStamp = new Date();
-    let fields = ["DATE-long", "DATE-short", "TIME-seconds", "TIME-noseconds"];
+    let fields = ["DATE-long", "DATE-short", "DATE-monthname", "TIME-seconds", "TIME-noseconds"];
     for (let i=0; i < fields.length; i++) {
         let field = fields[i];
         let fieldinfo = field.split("-");


### PR DESCRIPTION
Added `DATE=monthname` tag to insert month name in the template.

**Motivation**
I had to frequently send emails where I have to put current month in the email title and body. It is something like:
**Title**: Invoice for January
**Body**: Dear customer, please find enclosed invoice for January...