### PR TITLE
Feature LangDetect (make template with 2 different languages)

### DIFF
--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -505,66 +505,67 @@ var quicktext = {
 ,
   insertBody: function(aStr, aType, aHandleTransaction)
   {
-	var editor = GetCurrentEditor();
+    var editor = GetCurrentEditor();
 
     if (aStr != "")
     {
       aStr = gQuicktextVar.parse(aStr);
 	  
-	  
-//*******  LangSelector Code  **************
-		var LangSep, Reg_exp = null;
-		while(true){
-			LangSep = "***[CH]***"; if(aStr.includes(LangSep)) {Reg_exp = /[á-žÁ-Ž]/g; break;}			//= "***[CH]***";
-			LangSep = "***[DE]***"; if(aStr.includes(LangSep)) {Reg_exp = /[öäüÖÄÜß]/g; break;	}		//= "***[DE]***";
-			LangSep = "***[ES]***"; if(aStr.includes(LangSep)) {Reg_exp = /[áéíñóúÁÉÍÑÓÚ]/g; break;}		//= "***[ES]***";
-			LangSep = "***[FR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[àâæçêîôœÀÂÆÇÊÎÔŒ]/g;break;}	//= "***[FR]***";
-			LangSep = "***[GR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[α-ωΑ-Ω]/g; break;}			//= "***[GR]***";
-			LangSep = "***[PL]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ąćęłńóśźżĄĘŁŃÓŚŹŻ]/g; break;}//= "***[PL]***";
-			LangSep = "***[RO]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ĂăÂâÎîȘșŞşȚțŢţ]/g; break;}	//= "***[RO]***";
-			LangSep = "***[RU]***"; if(aStr.includes(LangSep)) {Reg_exp = /[а-яА-Я]/g; break;}			//= "***[RU]***";
-			LangSep = "***[TR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ıöüçğşİÖÜÇĞŞ]/g; break;}		//= "***[TR]***";
-			LangSep = ""; break; // default: pattern not founded
-		}
+      var LangSep, Reg_exp = null;
+      while(true){
+        LangSep = "***[CH]***"; if(aStr.includes(LangSep)) {Reg_exp = /[á-žÁ-Ž]/g; break;}
+        LangSep = "***[DE]***"; if(aStr.includes(LangSep)) {Reg_exp = /[öäüÖÄÜß]/g; break;}
+        LangSep = "***[ES]***"; if(aStr.includes(LangSep)) {Reg_exp = /[áéíñóúÁÉÍÑÓÚ]/g; break;}
+        LangSep = "***[FR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[àâæçêîôœÀÂÆÇÊÎÔŒ]/g; break;}
+        LangSep = "***[GR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[α-ωΑ-Ω]/g; break;}
+        LangSep = "***[PL]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ąćęłńóśźżĄĘŁŃÓŚŹŻ]/g; break;}
+        LangSep = "***[RO]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ĂăÂâÎîȘșŞşȚțŢţ]/g; break;}
+        LangSep = "***[RU]***"; if(aStr.includes(LangSep)) {Reg_exp = /[а-яА-Я]/g; break;}
+        LangSep = "***[TR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ıöüçğşİÖÜÇĞŞ]/g; break;}
+        LangSep = ""; break; // default: pattern not found
+      }
 		
-		if(Reg_exp == null) // did not matched! Try found direct RegExp...
-		{
-			var SttIdx = aStr.indexOf("***["); 
-			var EndIdx = aStr.indexOf("]***"); 
-//alert("StrIdx = " + SttIdx + ", EndIdx =" + EndIdx);					
-			if((SttIdx > 0) && (EndIdx > 0))
-			{
-				Reg_exp = new RegExp("[" + aStr.substring(SttIdx+4, EndIdx)+ "]", 'g');
-				LangSep = aStr.substring(SttIdx, EndIdx+4);
-			}
-		}
-//alert("Sep = " + LangSep + ", RegExp =" + Reg_exp);
+      if(Reg_exp == null) // did not matched. Try found RegExp directly writed
+      {
+        var SttIdx = aStr.indexOf("***["); 
+        var EndIdx = aStr.indexOf("]***"); 				
+        if((SttIdx > 0) && (EndIdx > 0))
+        {
+          Reg_exp = new RegExp("[" + aStr.substring(SttIdx+4, EndIdx)+ "]", 'g');
+          LangSep = aStr.substring(SttIdx, EndIdx+4);
+        }
+      }
 
-		if(Reg_exp != null) // Separator detected!
-		{		
-			var Texts = aStr.split(LangSep);
-			// get the text of body
-			editor.beginTransaction();
-			var tempString = editor.outputToString('text/plain', 8); // Body Only (text, no HTML)
-			editor.endTransaction();  // this is very impt, remember to end transaction.
-// alert(tempString);
-			tempString = tempString.replace(/(\r?\n){2,}/g, '$1');
-			if(tempString.indexOf("\n") <10)
-				tempString = tempString.substring(tempString.indexOf("\n")+1,500);
-				  
-			var WroteIdx = tempString.indexOf("\n"); // search the end of 1st string			
-			tempString = tempString.substring(WroteIdx+1,500); // delete 1st string and cut 500 symbols max. by remain text
-// alert(tempString);
-			aStr = Texts[0]; // English version is by Default
-			
-			var result = tempString.match(Reg_exp); // Check matches of non-english symbols
-			if(result != null) // globally: matches found?
-			{
-				if(result.length > 9)  // Count of matched symbols must be at least 10
-					aStr = Texts[1];				
-			}
-		}
-//*******  END OF LangSelector Code  **************
+      if(Reg_exp != null) // Separator detected!
+      {		
+        var Texts = aStr.split(LangSep);
+        var result = null; 
+        // get the text of body
+        editor.beginTransaction();
+        var tempString = editor.outputToString('text/plain', 8); // Body Only (text, no HTML)
+        editor.endTransaction();  // this is very impt, remember to end transaction.
+
+        tempString = tempString.replace(/(\r?\n){2,}/g, '$1');
+        if(tempString.indexOf("\n") <10)
+          tempString = tempString.substring(tempString.indexOf("\n")+1, 500);
+            
+        var WroteIdx = tempString.indexOf("\n"); // search the end of 1st string			
+        tempString = tempString.substring(WroteIdx+1, 500); // delete 1st string and cut 500 symbols max. by remain text
+        
+        aStr = Texts[0]; // English version is by Default
+        
+        try{
+          result = tempString.match(Reg_exp); // Find all non-English symbols
+        }
+        catch(e) {
+          alert("Some error in your LangSeparator RegExp. Please check it." );
+        }
+        if(result != null) // At all, symbols present?
+        {
+          if(result.length > 9)  // The count of matched symbols must be at least 10
+            aStr = Texts[1];				
+        }
+      }
 
       if (aStr != "")
       {

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -505,16 +505,73 @@ var quicktext = {
 ,
   insertBody: function(aStr, aType, aHandleTransaction)
   {
+	var editor = GetCurrentEditor();
+
     if (aStr != "")
     {
       aStr = gQuicktextVar.parse(aStr);
+	  
+	  
+//*******  LangSelector Code  **************
+		var LangSep, Reg_exp = null;
+		while(true){
+			LangSep = "***[CH]***"; if(aStr.includes(LangSep)) {Reg_exp = /[á-žÁ-Ž]/g; break;}			//= "***[CH]***";
+			LangSep = "***[DE]***"; if(aStr.includes(LangSep)) {Reg_exp = /[öäüÖÄÜß]/g; break;	}		//= "***[DE]***";
+			LangSep = "***[ES]***"; if(aStr.includes(LangSep)) {Reg_exp = /[áéíñóúÁÉÍÑÓÚ]/g; break;}		//= "***[ES]***";
+			LangSep = "***[FR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[àâæçêîôœÀÂÆÇÊÎÔŒ]/g;break;}	//= "***[FR]***";
+			LangSep = "***[GR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[α-ωΑ-Ω]/g; break;}			//= "***[GR]***";
+			LangSep = "***[PL]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ąćęłńóśźżĄĘŁŃÓŚŹŻ]/g; break;}//= "***[PL]***";
+			LangSep = "***[RO]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ĂăÂâÎîȘșŞşȚțŢţ]/g; break;}	//= "***[RO]***";
+			LangSep = "***[RU]***"; if(aStr.includes(LangSep)) {Reg_exp = /[а-яА-Я]/g; break;}			//= "***[RU]***";
+			LangSep = "***[TR]***"; if(aStr.includes(LangSep)) {Reg_exp = /[ıöüçğşİÖÜÇĞŞ]/g; break;}		//= "***[TR]***";
+			LangSep = ""; break; // default: pattern not founded
+		}
+		
+		if(Reg_exp == null) // did not matched! Try found direct RegExp...
+		{
+			var SttIdx = aStr.indexOf("***["); 
+			var EndIdx = aStr.indexOf("]***"); 
+//alert("StrIdx = " + SttIdx + ", EndIdx =" + EndIdx);					
+			if((SttIdx > 0) && (EndIdx > 0))
+			{
+				Reg_exp = new RegExp("[" + aStr.substring(SttIdx+4, EndIdx)+ "]", 'g');
+				LangSep = aStr.substring(SttIdx, EndIdx+4);
+			}
+		}
+//alert("Sep = " + LangSep + ", RegExp =" + Reg_exp);
+
+		if(Reg_exp != null) // Separator detected!
+		{		
+			var Texts = aStr.split(LangSep);
+			// get the text of body
+			editor.beginTransaction();
+			var tempString = editor.outputToString('text/plain', 8); // Body Only (text, no HTML)
+			editor.endTransaction();  // this is very impt, remember to end transaction.
+// alert(tempString);
+			tempString = tempString.replace(/(\r?\n){2,}/g, '$1');
+			if(tempString.indexOf("\n") <10)
+				tempString = tempString.substring(tempString.indexOf("\n")+1,500);
+				  
+			var WroteIdx = tempString.indexOf("\n"); // search the end of 1st string			
+			tempString = tempString.substring(WroteIdx+1,500); // delete 1st string and cut 500 symbols max. by remain text
+// alert(tempString);
+			aStr = Texts[0]; // English version is by Default
+			
+			var result = tempString.match(Reg_exp); // Check matches of non-english symbols
+			if(result != null) // globally: matches found?
+			{
+				if(result.length > 9)  // Count of matched symbols must be at least 10
+					aStr = Texts[1];				
+			}
+		}
+//*******  END OF LangSelector Code  **************
 
       if (aStr != "")
       {
         // Inserts the text
         if (aStr != "" && !aStr.match(/^\s+$/))
         {
-          var editor = GetCurrentEditor();
+          
           if (aHandleTransaction)
             editor.beginTransaction();
   


### PR DESCRIPTION
This function can search in the original sender's message the local language symbols and detect the message as "English or Not (only) English", then inserts from your template only the PART (half) of text according with the language detected.

This function works for next already preSetted "local" LangCodes and their languages:
CH - Czech, Slovak, and Slovenian
DE - Deutch
ES - Spain
FR - France
GR - Greece
PL - Poland
RO - Romanian
RU - Russian
TR - Turkish

FORMAT OF TEMPLATE:
Your Template must be formatted as 2 parts of text:
part 1 (always top half of template) - your text translated on International language (ENGLISH) - normal for international messaging.
part 2 (always bottom half) - your original text writed on your local language.
Between of these 2 parts must be placed a special strong sequence of symbols named Separator:
`***[xx]***`

where "xx" is your language Code for proper detect the language of original sender's message.
If you don't see your language in this list, you can add your language by yourself.
Just put your local language symbols between the '[' and ']' of Separator signature.
Example:
for German lang, the Separator may looks as `***[DE]***` or `***[öäüÖÄÜß]***`
or for Greek lang the Separator may looks as: `***[GR]***` or `***[α-ωΑ-Ω]***`
Example for QuickText template by the Editor window:

Hello
This is your text translated to the International Language, it is always ENGLISH.
Bla-bla-bla here is yor text on English.

Here is your End Sign:
With best regards, forever yours.
`***[RU]***`
Здравствуйте

Это ваш исходный текст письма на русском или другом локальном языке.
Здесь продолжение вашего текста, бла-бла-бла.

Здесь Ваша подпись:
Всего наилучшего, всегда Ваш.

Method of detection:
The function prepare the text of answer message visible in the window of editor. It remove all empty strings, then delete 1st string with info "2019/05/11 ... you wrote:", just because this string is not by original source message of sender. Then it leave only first 500 symbols of message body because the message may have very long "history" and contains other non-actual symbols. If will be found 10 or more symbols by charset of "Separator" language, the function will take from template the Bottom Half (text with local language) and insert it to the editing message. In other cases will be inserted the top half of your template (default English).