### PR TITLE
Enhance FROM variables

### DIFF
--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -651,7 +651,13 @@ wzQuicktextVar.prototype = {
       'lastname': ''
     };
 
-    var card = this.getCardForEmail(this.mData['FROM'].data['email'].toLowerCase());
+    let card = this.getCardForEmail(identity.email.toLowerCase());
+    if (card == null && identity.escapedVCard != null)
+    {
+      const manager = Components.classes["@mozilla.org/abmanager;1"]
+        .getService(Components.interfaces.nsIAbManager);
+      card = manager.escapedVCardToAbCard(identity.escapedVCard);
+    }
     if (card != null)
     {
       var props = this.getPropertiesFromCard(card);

--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -640,10 +640,13 @@ wzQuicktextVar.prototype = {
     if (this.mData['FROM'] && this.mData['FROM'].checked)
       return this.mData['FROM'].data;
 
+    const identity = this.mWindow.getCurrentIdentity();
+
     this.mData['FROM'] = {};
     this.mData['FROM'].checked = true;
     this.mData['FROM'].data = {
-      'email': this.mWindow.getCurrentIdentity().email,
+      'email': identity.email,
+      'displayname': identity.fullName,
       'firstname': '',
       'lastname': ''
     };


### PR DESCRIPTION
This pull request tries to improve the availability of attributes in `FROM` in two ways:
1. The name given in the "Your Name" field of the account/identity is set as `displayname`. That way, a useful name of the sender should be available for most users. However, this value may be overwritten, if a vCard for the address is found.
2. If no contact is found in the personal addressbook for the sending email address, the vCard that can be set in the account/identity is used to fill the available values. I think some people already have set-up such a vCard and this avoids having to duplicate the values into a contact of oneself.

This probably also fixes #23.