### PR TITLE
Change default value of 3rd parameter to 2nd parameter

### DIFF
--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -366,7 +366,7 @@ wzQuicktextVar.prototype = {
     {
       // use ", " as default seperator
       let mainSep = (aVariables.length > 1) ? aVariables[1].replace(/\\n/g, "\n").replace(/\\t/g, "\t") : ", ";
-      let lastSep = (aVariables.length > 2) ? aVariables[2].replace(/\\n/g, "\n").replace(/\\t/g, "\t") : ", ";
+      let lastSep = (aVariables.length > 2) ? aVariables[2].replace(/\\n/g, "\n").replace(/\\t/g, "\t") : mainSep;
       
       // clone the data, so we can work on it without mod the source object
       let entries = data[aVariables[0]].slice(0);


### PR DESCRIPTION
IMO it is a bad idea to have the 3rd parameter default to ", ", I propose it to default to the 2nd parameter.
Using `[[TO=lastname| & ]]` with Mr. Smith and Mr. Jones currently results to `Smith, Jones` instead of my expectation: `Smith & Jones`.

As a workaround I have to use `[[TO=lastname| & | & ]]`.
IMO it should be fixed and published soon, as this breaks (broke) existing templates.