### PR TITLE
selection should not trim white space

### DIFF
--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -344,7 +344,7 @@ wzQuicktextVar.prototype = {
 ,  
   get_selection: function(aVariables)
   {
-    return TrimString(this.process_selection(aVariables));
+    return this.process_selection(aVariables);
   }
 ,
   get_from: function(aVariables)


### PR DESCRIPTION
As mentioned in issue #91.
IMO trimming leading or trailing whitespace is a bad idea.

If someone selects like this:
Lorem `ipsum `dolor sit amet

instead of this:
Lorem `ipsum` dolor sit amet

it would result in this text:
Lorem ipsumdolor sit amet