### PR TITLE
Header patch

### DIFF
--- a/chrome/content/modules/wzQuicktext.jsm
+++ b/chrome/content/modules/wzQuicktext.jsm
@@ -32,7 +32,8 @@ var gQuicktext = {
   mObserverList:        [],
   mOS:                  "WINNT",
   mCollapseState:       "",
-  mSelectionContent:    "" ,
+  mSelectionContent:    "",
+  mCurrentTemplate:     "";
   mStringBundle: Services.strings.createBundle("chrome://quicktext/locale/quicktext.properties")	
 ,
   get viewToolbar() { return this.mViewToolbar; },
@@ -774,17 +775,20 @@ var gQuicktext = {
             if (text.attachments != "")
               buffer += "\t\t\t\t<attachments><![CDATA["+ this.removeIllegalChars(text.attachments) +"]]></attachments>\n";
             
-            var headerLength = 0;
-            if (headerLength = text.getHeaderLength() > 0)
-            {
-              buffer += "\t\t\t\t<headers>\n";
-              for (var k = 0; k < headerLength; k++)
-              {
-                var header = text.getHeader(k);
-                buffer += "\t\t\t\t\t<header>\n\t\t\t\t\t\t<type><![CDATA["+ header.type +"]]></type>\n\t\t\t\t\t\t<value><![CDATA["+ header.value +"]]></value>\n\t\t\t\t\t</header>\n";
-              }
-              buffer += "\t\t\t\t</headers>\n";
-            }
+            // There seems to be no use to write dynamically gathered header informations from the last use of a template to the file
+            
+            // var headerLength = 0;
+            // if (headerLength = text.getHeaderLength() > 0)
+            // {
+            //   buffer += "\t\t\t\t<headers>\n";
+            //   for (var k = 0; k < headerLength; k++)
+            //   {
+            //     var header = text.getHeader(k);
+            //     buffer += "\t\t\t\t\t<header>\n\t\t\t\t\t\t<type><![CDATA["+ header.type +"]]></type>\n\t\t\t\t\t\t<value><![CDATA["+ header.value +"]]></value>\n\t\t\t\t\t</header>\n";
+            //   }
+            //   buffer += "\t\t\t\t</headers>\n";
+            // }
+            
             buffer += "\t\t\t</text>\n";
           }
           buffer += "\t\t</texts>\n\t</menu>\n";
@@ -883,13 +887,15 @@ var gQuicktext = {
                   tmp.subject = this.getTagValue(subElems[j], "subject");
                   tmp.attachments = this.getTagValue(subElems[j], "attachments");
 
-                  var headersTag = subElems[j].getElementsByTagName("headers");
-                  if (headersTag.length > 0)
-                  {
-                    var headers = headersTag[0].getElementsByTagName("header");
-                    for (var k = 0; k < headers.length; k++)
-                      tmp.addHeader(this.getTagValue(headers[k], "type"), this.getTagValue(headers[k], "value"));
-                  }
+                  // There seems to be no use to read dynamically gathered header informations from the last use of a template from the file
+
+                  // var headersTag = subElems[j].getElementsByTagName("headers");
+                  // if (headersTag.length > 0)
+                  // {
+                  //   var headers = headersTag[0].getElementsByTagName("header");
+                  //   for (var k = 0; k < headers.length; k++)
+                  //     tmp.addHeader(this.getTagValue(headers[k], "type"), this.getTagValue(headers[k], "value"));
+                  // }
 
                   subTexts.push(tmp);
                 }

--- a/chrome/content/modules/wzQuicktextTemplate.jsm
+++ b/chrome/content/modules/wzQuicktextTemplate.jsm
@@ -55,6 +55,11 @@ wzQuicktextTemplate.prototype = {
     this.mHeaders.splice(aIndex, 0);
   }
 ,
+  removeHeaders: function ()
+  {
+    this.mHeaders = [];
+  }
+,
   getHeaderLength: function()
   {
     return this.mHeaders.length;

--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -332,8 +332,8 @@ wzQuicktextVar.prototype = {
 ,
   get_header: function(aVariables)
   {
-    // We do not do anything here but to return an empty string, 
-    // to remove the header tags from the body.
+    gQuicktext.mCurrentTemplate.addHeader(aVariables[0], aVariables[1]);
+    // return an empty string, to remove the header tags from the body.
     return "";
   }
 ,

--- a/chrome/content/quicktext.js
+++ b/chrome/content/quicktext.js
@@ -333,19 +333,22 @@ var quicktext = {
       gQuicktextVar.cleanTagData();
 
       var text = gQuicktext.getText(aGroupIndex, aTextIndex, false);
+      text.removeHeaders();
+      gQuicktext.mCurrentTemplate = text;
+
+      // this parsing of the header informations isn't able to parse something like: [[HEADER=to|[[SCRIPT=getReciepients]]]]
+
+      // // Parse text for HEADER tags and move them to the header object
+      // let headers = text.text.match(/\[\[header=[^\]]*\]\]/ig);
+      // if (headers && Array.isArray(headers)) {
+      //   for (let header of headers) {
+      //     let parts = header.split(/=|\]\]|\|/);
+      //     if (parts.length==4) {
+      //       text.addHeader(parts[1], parts[2]);
+      //     }
+      //   }
+      // }
       
-      // Parse text for HEADER tags and move them to the header object
-      let headers = text.text.match(/\[\[header=[^\]]*\]\]/ig);
-      if (headers && Array.isArray(headers)) {
-        for (let header of headers) {
-          let parts = header.split(/=|\]\]|\|/);
-          if (parts.length==4) {
-            text.addHeader(parts[1], parts[2]);
-          }
-        }
-      }
-      
-      this.insertHeaders(text);
       this.insertSubject(text.subject);
       this.insertAttachments(text.attachments);
 
@@ -357,6 +360,9 @@ var quicktext = {
       }
 
       await this.insertBody(text.text, text.type, aHandleTransaction);
+
+      // has to be inserted below "insertBody" as "insertBody" gathers the header data from the header tags
+      this.insertHeaders(text);
 
       // If we insert any headers we maybe needs to return the placement of the focus
       setTimeout(function () {quicktext.moveFocus();}, 1);


### PR DESCRIPTION
Support syntax like: `[[HEADER=to|[[SCRIPT=getReciepients]]]]`
let `insertBody` gather the header data from the header tags

Don't write and read header data:
There seems to be no use to write/read dynamically gathered header informations from the last use of a template to/from the file

Remove gathered header informations from the last use by implementing `removeHeaders` to clear the data