### PR TITLE
Update messages.json

### DIFF
--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -1,5 +1,8 @@
 {
   "extensionDescription": {
     "message": "Eszköztár, parancsfájlok és sablonok korlátlan lehetoségekkel, beleértve a [[TO=firstname]] változókat, a gyors szövegbeillesztéshez"
+  },
+  "extensionName": {
+    "message": "Gyorsszöveg"
   }
 }


### PR DESCRIPTION
Instead of the English text, i.e. `Quicktext`, being shown in the `Mail Toolbar` and `Composition Toolbar`, hopefully this will enable `Gyorsszöveg` to be shown when the `hu` locale is active.

Don't understand why `Gyorsszöveg` is not showing as it has been translated here: https://github.com/jobisoft/quicktext/blob/TB78/chrome/locale/hu/quicktext.dtd#L1