### PR TITLE
fix caching

### DIFF
--- a/chrome/content/modules/wzQuicktext.jsm
+++ b/chrome/content/modules/wzQuicktext.jsm
@@ -819,6 +819,7 @@ var gQuicktext = {
   {
     var req = new XMLHttpRequest();
     req.open('GET', aURI, true);
+    req.setRequestHeader("Cache-Control", "no-cache, no-store, max-age=0");
     req.mQuicktext = this;
     req.mType = aType;
     req.mBefore = aBefore;


### PR DESCRIPTION
Previously, sometimes a cached version of the templates/scripts in "import on startup" was used instead of downloading the newest xml file on startup.
This commit fixes that.