### PR TITLE
Scripts now support async

### DIFF
--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -584,7 +584,7 @@ wzQuicktextVar.prototype = {
           s.mQuicktext = this;
           s.mVariables = aVariables;
           s.mWindow = this.mWindow;
-          returnValue = await Components.utils.evalInSandbox("scriptObject = {}; scriptObject.mQuicktext = mQuicktext; scriptObject.mVariables = mVariables; scriptObject.mWindow = mWindow; scriptObject.run = async function() {\n" + script.script +"\n }; scriptObject.run();", s);
+          returnValue = await Components.utils.evalInSandbox("scriptObject = {}; scriptObject.mQuicktext = mQuicktext; scriptObject.mVariables = mVariables; scriptObject.mWindow = mWindow; scriptObject.run = async function() {\n" + script.script +"\n; return ''; }; scriptObject.run();", s);
         } catch (e) {
           if (this.mWindow)
           {

--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -307,9 +307,9 @@ wzQuicktextVar.prototype = {
     return this.process_text(aVariables);
   }
 ,
-  get_script: function(aVariables)
+  get_script: async function(aVariables)
   {
-    return this.process_script(aVariables);
+    return await this.process_script(aVariables);
   }
 ,
   get_att: function(aVariables)
@@ -555,7 +555,7 @@ wzQuicktextVar.prototype = {
     return "";
   }
 ,
-  process_script: function(aVariables)
+  process_script: async function(aVariables)
   {
     if (aVariables.length == 0)
       return "";
@@ -584,7 +584,7 @@ wzQuicktextVar.prototype = {
           s.mQuicktext = this;
           s.mVariables = aVariables;
           s.mWindow = this.mWindow;
-          returnValue = Components.utils.evalInSandbox("scriptObject = {}; scriptObject.mQuicktext = mQuicktext; scriptObject.mVariables = mVariables; scriptObject.mWindow = mWindow; scriptObject.run = function() {\n" + script.script +"\nreturn ''; }; scriptObject.run();", s);
+          returnValue = await Components.utils.evalInSandbox("scriptObject = {}; scriptObject.mQuicktext = mQuicktext; scriptObject.mVariables = mVariables; scriptObject.mWindow = mWindow; scriptObject.run = async function() {\n" + script.script +"\n }; scriptObject.run();", s);
         } catch (e) {
           if (this.mWindow)
           {


### PR DESCRIPTION
Scripting now supports async scripts. I tested with the following scripts:

----

**fully synchronous script:**
`return "Sync"`
Output: `Sync`

----

**Script using promises:**
```
const myPromise = new Promise((resolve, reject) => {mWindow.setTimeout(() => {resolve('Promise'); }, 1000);});
return myPromise;
```
Output: `Promise`

----

**Script with syntax errors:**
```
text = 'Error'
return text2;
```
Error message: 
```
In Ihrem Quicktext-Skript ist ein Fehler aufgetreten: Error
ReferenceError: text2 is not defined
Zeile 2: return text2;
```

----


**Script with no output at all:**
`"Missing Return statement here"`
Output: `no return statement in script`

----

**Script with await statement:**
```
data = await mQuicktext.get_url(["http://example.com/"])
return data;
```

Output: 
```
<!doctype html>
<html>
... <and more content of the requested page>
```