### PR TITLE
Update addon-developer-support and use Services global variable if possible

### DIFF
--- a/api/LegacyPrefs/README.md
+++ b/api/LegacyPrefs/README.md
@@ -4,7 +4,24 @@ Use this API to access Thunderbird's system preferences or to migrate your own p
 
 ## Usage
 
-This API provides the following methods:
+Add the [LegacyPrefs API](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/LegacyPrefs) to your add-on. Your `manifest.json` needs an entry like this:
+
+```
+  "experiment_apis": {
+    "LegacyPrefs": {
+      "schema": "api/LegacyPrefs/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["LegacyPrefs"]],
+        "script": "api/LegacyPrefs/implementation.js"
+      }
+    }
+  },
+```
+
+## API Functions
+
+This API provides the following functions:
 
 ### async getPref(aName, [aFallback])
 
@@ -21,6 +38,22 @@ Clears the user defined value for preference ``aName``. Subsequent calls to ``ge
 ### async setPref(aName, aValue)
 
 Set the ``aName`` preference to the given value. Will return false and log an error to the console, if the type of ``aValue`` does not match the type of the preference.
+
+## API Events
+
+This API provides the following events:
+
+### onChanged.addListener(listener, branch)
+
+Register a listener which is notified each time a value in the specified branch is changed. The listener returns the name and the new value of the changed preference.
+
+Example:
+
+```
+browser.LegacyPrefs.onChanged.addListener(async (name, value) => {
+  console.log(`Changed value in "mailnews.": ${name} = ${value}`);
+}, "mailnews.");
+```
 
 ---
 

--- a/api/LegacyPrefs/schema.json
+++ b/api/LegacyPrefs/schema.json
@@ -17,23 +17,17 @@
             "type": "any",
             "description": "Value of the preference."
           }
+        ],
+        "extraParameters": [
+          {
+            "name": "branch",
+            "description": "The branch to observe.",
+            "type": "string"
+          }
         ]
       }
     ],
     "functions": [
-      {
-        "name": "setObservingBranch",
-        "type": "function",
-        "async": true,
-        "description": "Set the branch which onChanged should be sensitive for.",
-        "parameters": [
-          {
-            "name": "aBranch",
-            "type": "string",
-            "description": "Name of the branch to observe."
-          }
-        ]
-      },
       {
         "name": "getUserPref",
         "type": "function",
@@ -60,7 +54,7 @@
           },
           {
             "name": "aFallback",
-            "type": "string",
+            "type": "any",
             "description": "Value to be returned, if the requested preference does not exist.",
             "optional": true,
             "default": null

--- a/api/NotifyTools/README.md
+++ b/api/NotifyTools/README.md
@@ -10,6 +10,10 @@ and back in when the task has been finished.
 
 More details can be found in [this update tutorial](https://github.com/thundernest/addon-developer-support/wiki/Tutorial:-Convert-add-on-parts-individually-by-using-a-messaging-system).
 
+# Example
+
+This repository includes the [NotifyToolsExample Add-On](https://github.com/thundernest/addon-developer-support/raw/master/auxiliary-apis/NotifyTools/notifyToolsExample.zip), showcasing how the NotifyTools can be used.
+
 # Usage
 
 Add the [NotifyTools API](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/NotifyTools) to your add-on. Your `manifest.json` needs an entry like this:
@@ -21,7 +25,8 @@ Add the [NotifyTools API](https://github.com/thundernest/addon-developer-support
       "parent": {
         "scopes": ["addon_parent"],
         "paths": [["NotifyTools"]],
-        "script": "api/NotifyTools/implementation.js"
+        "script": "api/NotifyTools/implementation.js",
+        "events": ["startup"]
       }
     }
   },
@@ -55,7 +60,7 @@ notifyTools.notifyBackground({command: "doSomething"}).then((data) => {
 });
 ```
 
-Include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script in your Experiment script to be able to use `notifyTools.notifyBackground()`.
+Include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script in your Experiment script to be able to use `notifyTools.notifyBackground()`. If you are injecting the script into a global Thunderbird window object, make sure to wrap it in your custom namespace, to prevent clashes with other add-ons.
 
 **Note**: If multiple `onNotifyBackground` listeners are registered in the WebExtension's background page and more than one is returning data, the value
 from the first one is returned to the Experiment. This may lead to inconsistent behavior, so make sure that for each
@@ -74,9 +79,9 @@ messenger.NotifyTools.notifyExperiment({command: "doSomething"}).then((data) => 
 
 The receiving Experiment script needs to include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script  and must setup a listener using the following methods:
 
-### registerListener(callback);
+### addListener(callback);
 
-Registers a callback function, which is called when a notification from the WebExtension's background page has been received. The `registerListener()` function returns an `id` which can be used to remove the listener again.
+Adds a callback function, which is called when a notification from the WebExtension's background page has been received. The `addListener()` function returns an `id` which can be used to remove the listener again.
 
 Example:
 
@@ -85,8 +90,47 @@ function doSomething(data) {
   console.log(data);
   return true;
 }
-let id = notifyTools.registerListener(doSomething);
+let id = notifyTools.addListener(doSomething);
 ```
+
+**Note**: NotifyTools currently is not 100% compatible with the behavior of
+runtime.sendMessage. While runtime messaging is ignoring non-Promise return
+values, NotifyTools only ignores `null`.
+
+Why does this matter? Consider the following three listeners:
+ 
+```
+async function dominant_listener(data) {
+ if (data.type == "A") {
+   return { msg: "I should answer only type A" };
+ }
+}
+ 
+function silent_listener(data) {
+ if (data.type == "B") {
+   return { msg: "I should answer only type B" };
+ }
+}
+
+function selective_listener(data) {
+ if (data.type == "C") {
+   return Promise.resolve({ msg: "I should answer only type C" });
+ }
+}
+```
+ 
+When all 3 listeners are registered for the runtime.onMessage event,
+the dominant listener will always respond, even for `data.type != "A"` requests,
+because it is always returning a Promise (it is an async function). The return
+value of the silent listener is ignored, and the selective listener returns a
+value just for `data.type == "C"`. But since the dominant listener also returns
+`null` for these requests, the actual return value depends on which listener is faster
+and/or was registered first.
+ 
+All notifyTools listener however ignore only `null` return values (so `null` can
+actually never be returned). The above dominant listener will only respond to 
+`type == "A"` requests, the silent listener will only respond to `type == "B"` 
+requests and the selective listener will respond only to `type == "C"` requests.
 
 ### removeListener(id)
 
@@ -98,10 +142,10 @@ Example:
 notifyTools.removeListener(id);
 ```
 
-### enable()
+### removeAllListeners()
 
-The [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script attaches its `enable()` method to the `load` event of the current window. If the script is loaded into a window-less environment, `enable()` needs to be called manually.
+You must remove all added listeners when your add-on is disabled/reloaded. Instead of calling `removeListener()` for each added listener, you may call `removeAllListeners()`.
 
-### disable()
+### setAddOnId(add-on-id)
 
-The [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script attaches its `disable()` method to the `unload` event of the current window. If the script is loaded into a window-less environment, `disable()` needs to be called manually.
+The `notifyTools.js` script needs to know the ID of your add-on to be able to listen for messages. You may either define the ID directly in the first line of the script, or set it using `setAddOnId()`.

--- a/api/NotifyTools/schema.json
+++ b/api/NotifyTools/schema.json
@@ -1,6 +1,6 @@
 [
   {
-    "namespace": "NotifyTools",    
+    "namespace": "NotifyTools",
     "events": [
       {
         "name": "onNotifyBackground",

--- a/api/WindowListener/CHANGELOG.md
+++ b/api/WindowListener/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version: 1.62
+-------------
+- fix bug in fullyLoaded()
+
+Version: 1.61
+-------------
+- adjusted to Thunderbird Supernova (Services is now in globalThis)
+
 Version: 1.60
 -------------
 - explicitly set hasAddonManagerEventListeners flag to false on uninstall

--- a/api/WindowListener/implementation.js
+++ b/api/WindowListener/implementation.js
@@ -2,7 +2,7 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
- * Version: 1.60
+ * Version 1.62
  *
  * Author: John Bieling (john@thunderbird.net)
  *
@@ -18,7 +18,8 @@ var { ExtensionCommon } = ChromeUtils.import(
 var { ExtensionSupport } = ChromeUtils.import(
   "resource:///modules/ExtensionSupport.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 
 function getThunderbirdVersion() {
   let parts = Services.appinfo.version.split(".");
@@ -402,9 +403,8 @@ var WindowListener_102 = class extends ExtensionCommon.ExtensionAPI {
           let url = context.extension.rootURI.resolve(defaultUrl);
 
           let prefsObj = {};
-          prefsObj.Services = ChromeUtils.import(
-            "resource://gre/modules/Services.jsm"
-          ).Services;
+          prefsObj.Services = globalThis.Services||
+            ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
           prefsObj.pref = function (aName, aDefault) {
             let defaults = Services.prefs.getDefaultBranch("");
             switch (typeof aDefault) {
@@ -1476,9 +1476,8 @@ var WindowListener_115 = class extends ExtensionCommon.ExtensionAPI {
           let url = context.extension.rootURI.resolve(defaultUrl);
 
           let prefsObj = {};
-          prefsObj.Services = ChromeUtils.import(
-            "resource://gre/modules/Services.jsm"
-          ).Services;
+          prefsObj.Services = globalThis.Services||
+            ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
           prefsObj.pref = function (aName, aDefault) {
             let defaults = Services.prefs.getDefaultBranch("");
             switch (typeof aDefault) {
@@ -1678,8 +1677,8 @@ var WindowListener_115 = class extends ExtensionCommon.ExtensionAPI {
 
   async _loadIntoWindow(window, isAddonActivation) {
     const fullyLoaded = async window => {
-      for (let i = 0; i < 10; i++) {
-        await this.sleep(100);
+      for (let i = 0; i < 20; i++) {
+        await this.sleep(50);
         if (
           window &&
           window.location.href != "about:blank" &&
@@ -1688,9 +1687,15 @@ var WindowListener_115 = class extends ExtensionCommon.ExtensionAPI {
           return;
         }
       }
+      throw new Error("Window ignored");
     }
 
-    await fullyLoaded(window);
+    try {
+      await fullyLoaded(window);
+    } catch(ex) {
+      return;
+    }
+
     if (!window || window.hasOwnProperty(this.uniqueRandomID)) {
       return;
     }

--- a/chrome/content/modules/utils.jsm
+++ b/chrome/content/modules/utils.jsm
@@ -2,7 +2,9 @@
 
 var EXPORTED_SYMBOLS = ["quicktextUtils"]
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 var quicktextUtils = {
   get dateTimeFormat() {

--- a/chrome/content/modules/wzQuicktext.jsm
+++ b/chrome/content/modules/wzQuicktext.jsm
@@ -1,7 +1,9 @@
 var { wzQuicktextGroup } = ChromeUtils.import("chrome://quicktext/content/modules/wzQuicktextGroup.jsm");
 var { wzQuicktextTemplate } = ChromeUtils.import("chrome://quicktext/content/modules/wzQuicktextTemplate.jsm");
 var { wzQuicktextScript } = ChromeUtils.import("chrome://quicktext/content/modules/wzQuicktextScript.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 var EXPORTED_SYMBOLS = ["gQuicktext"];
 

--- a/chrome/content/modules/wzQuicktextVar.jsm
+++ b/chrome/content/modules/wzQuicktextVar.jsm
@@ -1,6 +1,8 @@
 var EXPORTED_SYMBOLS = ["wzQuicktextVar"];
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 var { quicktextUtils } = ChromeUtils.import("chrome://quicktext/content/modules/utils.jsm");
 var { gQuicktext } = ChromeUtils.import("chrome://quicktext/content/modules/wzQuicktext.jsm");
 var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");

--- a/chrome/content/scripts/messenger.js
+++ b/chrome/content/scripts/messenger.js
@@ -1,5 +1,7 @@
 // Import any needed modules.
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 var { gQuicktext } = ChromeUtils.import("chrome://quicktext/content/modules/wzQuicktext.jsm");
 
 // Load an additional JavaScript file.

--- a/chrome/content/scripts/messengercompose.js
+++ b/chrome/content/scripts/messengercompose.js
@@ -1,5 +1,7 @@
 // Import any needed modules.
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 // Load an additional JavaScript file.
 Services.scriptloader.loadSubScript("chrome://quicktext/content/quicktext.js", window, "UTF-8");


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 .
Services global variable is available in WebExtensions experiments API global
from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 ,
and also available in all system globals from version 104
https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 ,
and those code doesn't have to import Services.jsm for recent versions.