### PR TITLE
Add CLIPBOARDHTML variable to get HTML data from clipboard

### DIFF
--- a/modules/quicktextParser.mjs
+++ b/modules/quicktextParser.mjs
@@ -847,9 +847,15 @@ export class QuicktextParser {
     this.mData['CLIPBOARD'].checked = true;
     this.mData['CLIPBOARD'].data = "";
 
-    // I do not know how to access html variant, but if, we would call
-    // this.getDetails and check isPlainText to determine if we need it.
-    this.mData['CLIPBOARD'].data = await navigator.clipboard.readText();
+    if (aVariables?.[0]?.toLowerCase?.() === "html") {
+      const items = await navigator.clipboard.read();
+      const htmlItem = items.find((item) => item.types.includes("text/html"));
+      if (htmlItem) {
+        this.mData['CLIPBOARD'].data = await (await htmlItem.getType("text/html")).text();
+      }
+    } else {
+      this.mData['CLIPBOARD'].data = await navigator.clipboard.readText();
+    }
 
     return this.mData['CLIPBOARD'].data;
   }

--- a/modules/quicktextParser.mjs
+++ b/modules/quicktextParser.mjs
@@ -839,28 +839,30 @@ export class QuicktextParser {
     return "";
   }
 
-  async process_clipboard(aVariables) {
+  async process_clipboard() {
     if (this.mData['CLIPBOARD'] && this.mData['CLIPBOARD'].checked)
       return this.mData['CLIPBOARD'].data;
 
     this.mData['CLIPBOARD'] = {};
     this.mData['CLIPBOARD'].checked = true;
-    this.mData['CLIPBOARD'].data = "";
 
-    if (aVariables?.[0]?.toLowerCase?.() === "html") {
-      const items = await navigator.clipboard.read();
-      const htmlItem = items.find((item) => item.types.includes("text/html"));
-      if (htmlItem) {
-        this.mData['CLIPBOARD'].data = await (await htmlItem.getType("text/html")).text();
-      }
-    } else {
-      this.mData['CLIPBOARD'].data = await navigator.clipboard.readText();
+    let html;
+    const items = await navigator.clipboard.read();
+    const htmlItem = items.find((item) => item.types.includes("text/html"));
+    if (htmlItem) {
+      html = await (await htmlItem.getType("text/html")).text();
     }
+
+    this.mData['CLIPBOARD'].data = {
+      html,
+      plain: await navigator.clipboard.readText(),
+    };
 
     return this.mData['CLIPBOARD'].data;
   }
   async get_clipboard(aVariables) {
-    return utils.trimString(await this.process_clipboard(aVariables));
+    const format = aVariables?.[0]?.toLowerCase?.() === "html" ? "html" : "plain";
+    return utils.trimString((await this.process_clipboard(aVariables))[format]);
   }
 
   async process_counter(aVariables) {

--- a/modules/quicktextParser.mjs
+++ b/modules/quicktextParser.mjs
@@ -846,7 +846,7 @@ export class QuicktextParser {
     this.mData['CLIPBOARD'] = {};
     this.mData['CLIPBOARD'].checked = true;
 
-    let html;
+    let html = "";
     const items = await navigator.clipboard.read();
     const htmlItem = items.find((item) => item.types.includes("text/html"));
     if (htmlItem) {


### PR DESCRIPTION
When you copy some cells from Libreoffice and insert into Thunderbird it messes up the style of your mail.

I use this `CLIPBOARDHTML` variable to clean/transform the inserted HTML from a script.

If I recall correctly, we previously had some mechanism to read HTML data from clipboard but now I think the only option we have is `CLIPBOARD` that unfortunately works for `text/plain` only.

I hope it can be useful for others too.