### PR TITLE
  fix: resolve popup positioning on Linux and race condition (#478, #527)

### DIFF
--- a/modules/utils.mjs
+++ b/modules/utils.mjs
@@ -261,11 +261,17 @@ export async function openPopup(tabId, config) {
     let lastFocusedWindow = parentId;
 
     const dimension = ({ top, left, width, height }) => {
+        // On Linux, skip centering if window is at origin (likely tiling WM: Hyprland, i3, sway, etc.)
+        // Windows/macOS always center since tiling WMs are rare/non-existent on those platforms
+        if (navigator.userAgent.includes('Linux') && top === 0 && left === 0) {
+            return {};
+        }
+
         const excessWidth = 100;
         const excessHeight = 100;
         return {
-            top: top + Math.round(0.5 * excessWidth),
-            left: left + Math.round(0.5 * excessHeight),
+            top: top + Math.round(0.5 * excessHeight),
+            left: left + Math.round(0.5 * excessWidth),
             width: width - excessWidth,
             height: height - excessHeight,
         }

--- a/modules/utils.mjs
+++ b/modules/utils.mjs
@@ -309,8 +309,13 @@ export async function openPopup(tabId, config) {
 
     };
     const onMessageListener = (info, sender, sendResponse) => {
+        // Validate windowId for all actions, allow first config request to set popupId to resolve race condition
         if (sender.tab.windowId != popupId) {
-            return false;
+            if (info?.action === "config" && !popupId) {
+                popupId = sender.tab.windowId;
+            } else {
+                return false;
+            }
         }
 
         switch (info?.action) {

--- a/modules/utils.mjs
+++ b/modules/utils.mjs
@@ -261,9 +261,9 @@ export async function openPopup(tabId, config) {
     let lastFocusedWindow = parentId;
 
     const dimension = ({ top, left, width, height }) => {
-        // On Linux, skip centering if window is at origin (likely tiling WM: Hyprland, i3, sway, etc.)
-        // Windows/macOS always center since tiling WMs are rare/non-existent on those platforms
-        if (navigator.userAgent.includes('Linux') && top === 0 && left === 0) {
+        // On Linux, skip centering for wayland compatability
+        // Windows/macOS always center
+        if (navigator.userAgent.includes('Linux')) {
             return {};
         }
 


### PR DESCRIPTION
 ## Summary
This PR fixes two separate pop-up bugs: one was specific to Linux (possibly wayland only?), and the other was a race condition affecting all platforms.

## Bug Fixes

### Issue #527: Incorrect positioning on Linux
- Skip centering on Linux
- Fix width/height variable swap bug in dimension calculation
- Preserves centered popup behavior on Windows/macOS

### Issue #478: Race condition in popup config loading
- Fixed race condition where `popup.js` requests config before `popupId` is set, resulting in no config and a blank pop-up window
- **Root cause:** Popup could load and send "config" message on line 121 before the `browser.windows.create()` promise resolved, causing the windowId validation to fail
- **Solution:** Allow first "config" request to capture and set `popupId` from sender
- Maintains security by validating all subsequent messages against the captured window ID