### PR TITLE
Update manager.css

### DIFF
--- a/dialogs/manager/manager.css
+++ b/dialogs/manager/manager.css
@@ -178,6 +178,10 @@ fieldset legend {
 .sidebar { width: max(220px, 23vw); flex-shrink: 0; }
 .detail { flex: 1; min-width: 0; }
 
+#template-tree, #script-list {
+  max-width: max(195px, calc(23vw - 25px));
+}
+
 .flex-fieldset {
   display: flex;
   flex-direction: column;
@@ -218,7 +222,7 @@ fieldset legend {
 .tree-template:hover { background: var(--bg-hover); }
 .tree-template.selected { background: var(--bg-selected); }
 .tree-template.drag-over { outline: 2px dashed var(--accent); }
-.tree-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: max(170px, calc(23vw - 50px)); }
+.tree-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tree-shortcut { font-size: 0.85em; color: var(--text-subtle); flex-shrink: 0; margin-left: 4px; }
 
 /* Detail area */

--- a/dialogs/manager/manager.css
+++ b/dialogs/manager/manager.css
@@ -163,7 +163,7 @@ fieldset legend {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 200px;
+  max-width: max(200px, calc(23vw - 20px));
 }
 .source-list li:last-child { border-bottom: none; }
 .source-list li:hover { background: var(--bg-hover); }
@@ -176,7 +176,7 @@ fieldset legend {
   gap: 6px;
   height: 100%;
 }
-.sidebar { width: 220px; flex-shrink: 0; }
+.sidebar { width: max(220px, 23vw); flex-shrink: 0; }
 .detail { flex: 1; min-width: 0; }
 
 .flex-fieldset {
@@ -219,7 +219,7 @@ fieldset legend {
 .tree-template:hover { background: var(--bg-hover); }
 .tree-template.selected { background: var(--bg-selected); }
 .tree-template.drag-over { outline: 2px dashed var(--accent); }
-.tree-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 170px; }
+.tree-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: max(170px, calc(23vw - 50px)); }
 .tree-shortcut { font-size: 0.85em; color: var(--text-subtle); flex-shrink: 0; margin-left: 4px; }
 
 /* Detail area */


### PR DESCRIPTION
The sidebar currently has a fixed width of 220px. This works well for smaller window sizes (~950px), but on larger screens (e.g., Full HD) the sidebar remains unnecessarily narrow.

It might be better to let the sidebar scale with the viewport width while keeping the same proportions. This CSS-changes work fine for me. (It keeps the current layout for smaller screens but allows the sidebar to grow on larger displays.)