### PR TITLE
Allow to make keywords case insensitve again

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -8,6 +8,9 @@
   "quicktext.controlledViaManagedStorage.label": {
     "message": "Über verwalteten Speicher gesteuert"
   },
+  "quicktext.caseinsensitive.label": {
+    "message": "Ignoriere groß/kleinschreibung bei Schlüsselwortern"
+  },
   "quicktext.date.label": {
     "message": "Datum ($P1$)",
     "placeholders": {

--- a/src/_locales/en-US/messages.json
+++ b/src/_locales/en-US/messages.json
@@ -8,6 +8,9 @@
   "quicktext.controlledViaManagedStorage.label": {
     "message": "Controlled via managed storage"
   },
+  "quicktext.caseinsensitive.label": {
+    "message": "Keywords are Case-insensitive"
+  },
   "quicktext.date.label": {
     "message": "Date ($P1$)",
     "placeholders": {

--- a/src/dialogs/manager/manager.html
+++ b/src/dialogs/manager/manager.html
@@ -52,6 +52,9 @@
                 </select>
                 <span id="lbl-keyword-setting" data-i18n-content="quicktext.keywordKeySetting.label"></span>
               </div>
+              <div>
+                <label><input type="checkbox" id="chk-keyword-ci"> <span id="lbl-chk-case-insensitive" data-i18n-content="quicktext.caseInsensitive.label"></span></label>
+              </div>
             </div>
           </fieldset>
         </div>

--- a/src/dialogs/manager/manager.js
+++ b/src/dialogs/manager/manager.js
@@ -133,7 +133,7 @@ async function _refreshVfsProviders() {
 async function loadAll() {
   const prefNames = [
     "popup", "menuCollapse", "shortcutModifier", "shortcutTypeAdv",
-    "keywordKey", "counter", "defaultImport",
+    "keywordKey", "keywordCaseinsensitive", "counter", "defaultImport",
   ];
   for (const pref of prefNames) {
     const { value, isManaged } = await storage.getPrefWithManagedInfo(pref);
@@ -280,6 +280,7 @@ async function saveAll() {
   await storage.setPref("shortcutModifier", state.prefs.shortcutModifier);
   await storage.setPref("shortcutTypeAdv", state.prefs.shortcutTypeAdv);
   await storage.setPref("keywordKey", state.prefs.keywordKey);
+  await storage.setPref("keywordCaseinsensitive", state.prefs.keywordCaseinsensitive);
   await storage.setPref("defaultImport", state.prefs.defaultImport);
   // The storage list (including enabled flags, type, name and
   // ordering) is part of the regular Save flow. Storage-list edits
@@ -391,6 +392,11 @@ function renderGeneral() {
   selKeyword.value = state.prefs.keywordKey;
   applyManaged(selKeyword, managed("keywordKey"));
   selKeyword.addEventListener("change", () => { state.prefs.keywordKey = selKeyword.value; markChanged(); });
+
+  const chkKeywordCI = document.getElementById("chk-keyword-ci");
+  chkKeywordCI.checked = state.prefs.keywordCaseinsensitive;
+  applyManaged(chkKeywordCI, managed("keywordCaseinsensitive"));
+  chkKeywordCI.addEventListener("change", () => { state.prefs.keywordCaseinsensitive = chkKeywordCI.checked; markChanged(); });
 
   document.getElementById("btn-reset-counter").addEventListener("click", () => {
     state.prefs.counter = 0;

--- a/src/modules/quicktext.mjs
+++ b/src/modules/quicktext.mjs
@@ -291,7 +291,7 @@ export async function getKeywordsAndShortcuts() {
           shortcuts[shortcut] = [bundle.storageUuid, i, j];
         }
 
-        let keyword = text.keyword;
+        let keyword = text.keyword.toLocaleLowerCase();
         if (keyword != "" && typeof keywords[keyword] == "undefined")
           keywords[keyword] = [bundle.storageUuid, i, j];
       }

--- a/src/modules/quicktext.mjs
+++ b/src/modules/quicktext.mjs
@@ -277,6 +277,7 @@ export async function processTag({ tabId, tag, variables }) {
 // without further logic to return a Promise.
 export async function getKeywordsAndShortcuts() {
   let bundles = await storage.getActiveStorageEntries();
+  let keywordCaseinsensitive = await storage.getPref("keywordCaseinsensitive");
   let keywords = {};
   let shortcuts = {};
 
@@ -291,8 +292,11 @@ export async function getKeywordsAndShortcuts() {
           shortcuts[shortcut] = [bundle.storageUuid, i, j];
         }
 
-        let keyword = text.keyword.toLocaleLowerCase();
+        let keyword = text.keyword;
         if (keyword != "" && typeof keywords[keyword] == "undefined")
+          if(keywordCaseinsensitive) {
+            keyword = keyword.toLowerCase();
+          }
           keywords[keyword] = [bundle.storageUuid, i, j];
       }
     }

--- a/src/modules/storage.mjs
+++ b/src/modules/storage.mjs
@@ -303,6 +303,7 @@ const defaultPrefs = {
   "toolbar": true,
   "popup": true,
   "keywordKey": "Tab",
+  "keywordCaseinsensitive": false,
   "shortcutModifier": "alt",
   "shortcutTypeAdv": false,
   "collapseState": "",
@@ -313,6 +314,7 @@ const managedPrefs = [
   "menuCollapse",
   "popup",
   "keywordKey",
+  "keywordCaseinsensitive",
   "shortcutModifier",
   "shortcutTypeAdv",
 ];

--- a/src/scripts/compose.js
+++ b/src/scripts/compose.js
@@ -146,7 +146,7 @@ function keywordListener(e) {
         // selection/cursor. We assume the keyword is not split between two nodes.
         let range = initialSelectionRange.cloneRange();
         range.setStart(range.startContainer, 0);
-        let lastWord = range.toString().split(" ").pop();
+        let lastWord = range.toString().split(" ").pop().toLocaleLowerCase();
 
         if (!lastWord || !keywords.hasOwnProperty(lastWord)) {
             return;

--- a/src/scripts/compose.js
+++ b/src/scripts/compose.js
@@ -8,7 +8,7 @@ const alternatives = {
     "Enter": ["NumpadEnter"]
 }
 
-let keywords, keywordKey, shortcutTypeAdv, shortcutModifier, shortcuts;
+let keywords, keywordKey, keywordCaseinsensitive, shortcutTypeAdv, shortcutModifier, shortcuts;
 let advShortcutModifierIsDown = false;
 let advShortcutString = "";
 let popoverShown = false;
@@ -146,7 +146,10 @@ function keywordListener(e) {
         // selection/cursor. We assume the keyword is not split between two nodes.
         let range = initialSelectionRange.cloneRange();
         range.setStart(range.startContainer, 0);
-        let lastWord = range.toString().split(" ").pop().toLocaleLowerCase();
+        let lastWord = range.toString().split(" ").pop();
+        if (keywordCaseinsensitive) {
+            lastWord = lastWord.toLocaleLowerCase();
+        }
 
         if (!lastWord || !keywords.hasOwnProperty(lastWord)) {
             return;
@@ -213,6 +216,7 @@ async function getLatestPrefs() {
     keywordKey = await storage.getPref("keywordKey");
     shortcutTypeAdv = await storage.getPref("shortcutTypeAdv");
     shortcutModifier = await storage.getPref("shortcutModifier");
+    keywordCaseinsensitive = await storage.getPref("keywordCaseinsensitive");
 
     let rv = await messenger.runtime.sendMessage({ command: "getKeywordsAndShortcuts" });
     keywords = rv.keywords;


### PR DESCRIPTION
In previous versions the keywords used to be case-insensitive. But now they aren't anymore. I struggle to get used to this change. So here is a PR to allow case-insensitive keywords search again.

First commit makes them always case-insenstive, but I can also see why people might like them case sensitive I then added an option to let the user choose.